### PR TITLE
fix 🐛 change api review news API url

### DIFF
--- a/src/components/ReviewBoard/ReviewList.tsx
+++ b/src/components/ReviewBoard/ReviewList.tsx
@@ -15,7 +15,7 @@ const ReviewList: FunctionComponent<ReviewListProps> = () => {
 
   useEffect(() => {
     axios
-      .get('/api/reviews/news/')
+      .get('/api/reviews/news')
       .then(
         ({
           data: {


### PR DESCRIPTION
리뷰 게시판 최신 게시글 리스트를 요청하는 API url을 변경하였습니다.
마지막에 '/' 를 붙이면 accessToken을 필요로 하는 api 이고, '/'를 붙이지 않으면 accessToken을 필요로 하지 않는 api 입니다.

#59